### PR TITLE
support extra field in W3C log file

### DIFF
--- a/Source/Tx.Windows/IIS/W3CEnumerable.cs
+++ b/Source/Tx.Windows/IIS/W3CEnumerable.cs
@@ -97,12 +97,17 @@ namespace Tx.Windows
                     timeIndex = i-1;
                     continue;
                 }
+                
+                PropertyInfo targetProperty = typeof(W3CRecord).GetProperty(property);
 
-                MemberBinding b = Expression.Bind(
-                    typeof(W3CEvent).GetProperty(property),
-                    Expression.ArrayIndex(args, Expression.Constant(i-1)));
+                if (targetProperty != null)
+                {
+                    MemberAssignment b = Expression.Bind(
+                        targetProperty,
+                        Expression.ArrayIndex(args, Expression.Constant(i - 1)));
 
-                bindings.Add(b);
+                    bindings.Add(b);
+                }
             }
 
             MemberBinding bdt = Expression.Bind(


### PR DESCRIPTION
In the current code, in the case where there is no field in W3CRecord was in the log file, it becomes NULL Exception.
